### PR TITLE
Update bleak version and Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Neosensory Python SDK
 
 **NOTE: This SDK is not fully working yet and we are not able to offer support for it at this time.** Members of the community are more than welcome to contribute, build off of this, and help test!
 
-A Python package for interacting with Neosensory products. This is designed to work with `Bleak <https://github.com/hbldh/bleak>`_, a cross-platform Python Bluetooth Low Energy (BLE) client for Windows, MacOS, and Linux. Please see the Bleak project page for more specifics on supported platforms. **IMPORTANT: At the moment this is tested and only working on Windows.**
+A Python package for interacting with Neosensory products. This is designed to work with `Bleak <https://github.com/hbldh/bleak>`_, a cross-platform Python Bluetooth Low Energy (BLE) client for Windows, MacOS, and Linux. Please see the Bleak project page for more specifics on supported platforms. **IMPORTANT: At the moment, this repository is tested on Windows, Linux as well as Raspbian 10 Buster**
 
 Requirements
 ============
@@ -32,6 +32,19 @@ Usage
 You may need to first pair your Neosensory Buzz in advance with your operating system (OS). To do so, find your OS's Bluetooth settings/panel and follow its instructions for pairing a new device. To put Buzz into pairing mode, hold down the (+) and (-) buttons until the LEDs flash blue.
 
 See this repo's `examples <https://github.com/neosensory/neosensory-sdk-for-python/tree/master/examples>`_ directory to get up and running quickly. 
+
+Troubleshooting
+=====
+If the script returns an error - 
+.. code-block:: bash
+	bleak.exc.BleakDBusError: org.bluez.Error.NotPermitted
+
+This means that you are using Bleak v0.11.0. You'll have to update the bleak version to v0.10.0. Usually, this does not occur, but in case it does, head over to the terminal and type - 
+.. code-block:: bash
+	pip install bleak==0.10.0
+	
+After this, it should work as intended. 
+
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -38,11 +38,13 @@ Troubleshooting
 If the script returns an error - 
 
 .. code-block:: bash
+
 	bleak.exc.BleakDBusError: org.bluez.Error.NotPermitted
 
 This means that you are using Bleak v0.11.0. You'll have to update the bleak version to v0.10.0. Usually, this does not occur, but in case it does, head over to the terminal and type - 
 
 .. code-block:: bash
+
 	pip install bleak==0.10.0
 	
 After this, it should work as intended. 

--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,12 @@ See this repo's `examples <https://github.com/neosensory/neosensory-sdk-for-pyth
 Troubleshooting
 =====
 If the script returns an error - 
+
 .. code-block:: bash
 	bleak.exc.BleakDBusError: org.bluez.Error.NotPermitted
 
 This means that you are using Bleak v0.11.0. You'll have to update the bleak version to v0.10.0. Usually, this does not occur, but in case it does, head over to the terminal and type - 
+
 .. code-block:: bash
 	pip install bleak==0.10.0
 	

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bleak
+bleak==0.10.0
 base64
 uuid


### PR DESCRIPTION
Just in case someone's trying to install the requirements from pip, updated the bleak version to avoid running into errors. Solved by @GreatScott here - https://github.com/neosensory/neosensory-sdk-for-python/issues/2